### PR TITLE
Hwpc 151 make region selection a primary requirement

### DIFF
--- a/static/js/accordion.js
+++ b/static/js/accordion.js
@@ -485,18 +485,7 @@ $("#previewbtn").click(function (e) {
       toggleAccordion($("#" + class_list[1])[0]);
       toggleAccordion($("#" + class_list[1])[0]);
     }
-    if (
-      class_list[1] == "acc-01" ||
-      class_list[1] == "acc-02" ||
-      class_list[1] == "acc-04" ||
-      class_list[1] == "acc-05" ||
-      class_list[1] == "acc-06" ||
-      class_list[1] == "acc-07"
-    ) {
-      console.log("2");
-      toggleAccordion($("#" + class_list[1])[0]);
-      toggleAccordion($("#" + class_list[1])[0]);
-    } else {
+    else {
       console.log("3");
       toggleAccordion($("#" + class_list[1])[0]);
     }
@@ -525,7 +514,7 @@ var modal_dict = {
   modal10:
     "Enter a number of Monte Carlo Simulations between 1000 and 5000 runs.<br /> A .csv file containing the distribution parameters.",
   modal11:
-    "Email is required to send you the zip file and link of simulation once complete.",
+    "Email is required to send you link of the completed simulation outputs.",
   modal12: "Name of Run to label zip file.",
 };
 

--- a/templates/components/accordion.html
+++ b/templates/components/accordion.html
@@ -87,7 +87,7 @@
                     class="nextbtn acc-02">Next</button>
             </span>
         </div>
-        <h1 id="acc-03" class="acc-h1" role="button" tabindex="0">Upload yearly primary product
+        <h1 id="acc-03" class="acc-h1" role="button" tabindex="0"><span>03</span>Upload yearly primary product
             ratios or
             choose region for default
             ratios</h1>
@@ -143,7 +143,7 @@
                 <i tabindex="0" class="cancel-upload-btn fa-solid fa-circle-xmark"></i>
         </div>
 
-        <h1 id="acc-04" class="acc-h2" role="button" tabindex="0"><span>03</span>Upload custom ratios (optional)</h1>
+        <h1 id="acc-04" class="acc-h2" role="button" tabindex="0"><span>04</span>Upload custom ratios (optional)</h1>
         <div>
             <h2 id="acc-04b" class="acc-h2" role="button" tabindex="0">Select end use in use discard method</h2>
 


### PR DESCRIPTION
An update to move primary product ratios out from the collective other ratios block and into it's own tab above it. This also contains a quick update for the preview data modal that will now correctly open tabs now that the validation tab opener now activates on the submit button rather than on the 7th tab opening.