### PR TITLE
fix for cancel buttons

### DIFF
--- a/static/js/accordion.js
+++ b/static/js/accordion.js
@@ -186,8 +186,17 @@ $(".cancel-upload-btn").click(function (e) {
   )[0].previousElementSibling.previousElementSibling.previousElementSibling.value =
     null;
   $(e.target)[0].previousElementSibling.value = null;
-  $(e.target)[0].previousElementSibling.placeholder = "Currently using default";
-  $("#regionselection").val("North Central").change();
+  if($(e.target)[0].previousElementSibling.previousElementSibling.previousElementSibling.id == "fu-yearly-harvest" 
+  || $(e.target)[0].previousElementSibling.previousElementSibling.previousElementSibling.id == "yearlytimberproductratios"){
+    $(e.target)[0].previousElementSibling.placeholder = "No file uploaded";
+  }
+  else if($(e.target)[0].previousElementSibling.previousElementSibling.previousElementSibling.id == "customregion" ){
+    $("#regionselection").val("North Central").change();
+    $(e.target)[0].previousElementSibling.placeholder = "Using default";
+  }
+  else{
+    $(e.target)[0].previousElementSibling.placeholder = "Using default";
+  }
 });
 
 $("#email-address").on("input", function () {


### PR DESCRIPTION
a nice fix for two bugs. First made a quick adjustment to properly show which inputs are important files by showing "No file uploaded", while optional inputs now show "Using default" after clicking the x button. Secondly, now only the cancel button in section 3 will properly reset the regions drop down value, which previously all cancel buttons could accidentally do that.